### PR TITLE
fixed the actions title in the admin view

### DIFF
--- a/src/app/[lang]/admin/userAdministration/useUserTableColumns.tsx
+++ b/src/app/[lang]/admin/userAdministration/useUserTableColumns.tsx
@@ -135,8 +135,8 @@ export function useUserTableColumns() {
                                         <MoreHorizontal className="h-4 w-4" />
                                     </Button>
                                 </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                    <DropdownMenuLabel>{dictionary?.adminPages.userAdministration.actions.copyID}</DropdownMenuLabel>
+                                <DropdownMenuContent align="end"> 
+                                    <DropdownMenuLabel>{dictionary?.adminPages.userAdministration.actions.actionsTitle}</DropdownMenuLabel>
                                     <DropdownMenuItem onClick={() => navigator.clipboard.writeText(user.id)}>
                                         {dictionary?.adminPages.userAdministration.actions.copyID}
                                     </DropdownMenuItem>

--- a/src/dictionaries/de.json
+++ b/src/dictionaries/de.json
@@ -27,6 +27,7 @@
                 "errorMessage": "Ein Fehler ist aufgetreten. Die Rolle des Benutzers konnte nicht aktualisiert werden."
             },
             "actions": {
+                "actionsTitle": "Aktionen",
                 "copyID": "ID kopieren",
                 "changeRoleToAdmin": "Rolle zu Administrator ändern",
                 "changeRoleToWorker": "Rolle zu Arbeiter ändern",

--- a/src/dictionaries/dictionary.ts
+++ b/src/dictionaries/dictionary.ts
@@ -28,6 +28,7 @@ export interface Dictionary {
                 errorMessage: string;
             };
             actions: {
+                actionsTitle: string;
                 copyID: string;
                 changeRoleToAdmin: string;
                 changeRoleToWorker: string;


### PR DESCRIPTION
feat(i18n): add actions title to user administration dictionary Adds the "actionsTitle" key to the German dictionary for user  administration. This change improves the localization by providing  a title for the actions section, enhancing user experience and  clarity in the interface.