### PR TITLE
fix: filter out users without names in admin page

### DIFF
--- a/src/app/[lang]/admin/userAdministration/page.tsx
+++ b/src/app/[lang]/admin/userAdministration/page.tsx
@@ -10,16 +10,19 @@ import { Loader2 } from "lucide-react";
 export default function UserAdministrationPage() {
   const { dictionary } = useDictionary();
   const { data: users, isLoading } = api.user.getUsers.useQuery();
+  
   const columns = UserTableColumns();
 
   if (isLoading) {
     return <Loader2 className="h-4 w-4 animate-spin" />;
   }
 
+  const filteredUsers = users?.filter(user => user.name) ?? [];
+
   return (
     <div className="container mx-auto py-10">
       <h1>{dictionary?.adminPages.userAdministration.mainTitle}</h1>
-      <DataTable columns={columns} data={users ?? []} />
+      <DataTable columns={columns} data={filteredUsers} />
     </div>
   );
 }


### PR DESCRIPTION
Filter the user list to exclude users without names in the  User Administration page. This change ensures that only valid  user entries are displayed, improving the clarity and  usability of the user management interface.