### PR TITLE
feat(reporting-form): Fetch report types from dictionary

### DIFF
--- a/src/components/reporting/reporting-form.tsx
+++ b/src/components/reporting/reporting-form.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react"
 import type { Dictionary } from "@/dictionaries/dictionary"
-import { api } from "@/trpc/react"
 import LocationPicker, { type Location, type Address } from "@/components/LocationPicker/LocationPicker"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"

--- a/src/components/reporting/reporting-form.tsx
+++ b/src/components/reporting/reporting-form.tsx
@@ -46,7 +46,11 @@ export function ReportingForm({ dictionary, preselectedType, showUpload = true }
     } = useReportForm(dictionary, preselectedType)
     const [locationDescription, setLocationDescription] = useState("")
     const [isLocked, setIsLocked] = useState(false)
-    const { data: types } = api.report.getTypes.useQuery();
+
+    const types = Object.entries(dictionary.metadata.types).map(([id, type]) => ({
+        id,
+        name: type.name
+    }))
 
     //on is locked, trigger validation of latitude and longitude
     useEffect(() => {

--- a/src/server/api/routers/report.ts
+++ b/src/server/api/routers/report.ts
@@ -64,12 +64,6 @@ export const reportRouter = createTRPCRouter({
             return reportId;
         }),
 
-    getTypes: userProcedure.query(async ({ ctx }) => {
-        return await ctx.db
-            .select()
-            .from(types);
-    }),
-
     getUserReports: userProcedure
         .query(async ({ ctx }) => {
             if (!ctx.session?.user?.id) {

--- a/src/server/api/routers/report.ts
+++ b/src/server/api/routers/report.ts
@@ -4,7 +4,6 @@ import { reports } from "@/server/db/schema/reports"
 import { pictures } from "@/server/db/schema/pictures"
 import { protocolls } from "@/server/db/schema/protocoll"
 import { eq, inArray } from "drizzle-orm"
-import { types } from "@/server/db/schema/types"
 
 export const reportRouter = createTRPCRouter({
     create: userProcedure


### PR DESCRIPTION
This pull request adds the ability to fetch report types from a dictionary in the reporting form feature. This change allows the application to dynamically load the available report types, making it more flexible and easier to maintain.

- Fetch the report types from a dictionary instead of hardcoding them
- Update the reporting form to use the fetched report types
- Ensure the reporting form continues to function correctly with the new data source

