### PR TITLE
feat(map): add filters to map legend

### DIFF
--- a/src/components/ReportOverview/Map/map-content.tsx
+++ b/src/components/ReportOverview/Map/map-content.tsx
@@ -88,7 +88,7 @@ export default function MapContent({
         : defaultCenter;
 
     return (
-        <div className="w-full h-[600px] rounded-lg overflow-hidden border border-border">
+        <div className="w-full h-[620px] rounded-lg overflow-hidden border border-border">
             <MapContainer
                 center={[center[0], center[1]]}
                 zoom={13}

--- a/src/components/ReportOverview/Map/map-legend.tsx
+++ b/src/components/ReportOverview/Map/map-legend.tsx
@@ -3,52 +3,80 @@ import { createSvgContent } from './map-content';
 
 interface LegendProps {
     dictionary: Dictionary;
+    filters: {
+        types: Set<number>;
+        statuses: Set<number>;
+        prios: Set<number>;
+    };
+    onFilterChange: (category: 'types' | 'statuses' | 'prios', id: number, checked: boolean) => void;
 }
 
-export default function Legend({ dictionary }: LegendProps) {
+export default function Legend({ dictionary, filters, onFilterChange }: LegendProps) {
     const dict = dictionary.metadata;
+    const legendDict = dictionary.components.mapLegend;
 
     return (
-        <div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 p-4 rounded-lg border shadow-lg w-[200px] h-fit">
-            <h3 className="font-medium mb-3">Legende</h3>
+        <div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 p-4 rounded-lg border shadow-lg w-[250px] h-[620px] h-fit">
+            <h3 className="font-medium mb-3">{legendDict.title}</h3>
             <div className="space-y-4 text-sm">
                 <div>
-                    <h4 className="font-medium mb-2">Typ</h4>
+                    <h4 className="font-medium mb-2">{legendDict.typeTitle}</h4>
                     <div className="space-y-2">
                         {(Object.keys(dict.types) as Array<keyof typeof dict.types>).map((type) => (
-                            <div key={type} className="flex items-center gap-2">
+                            <label key={type} className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={filters.types.has(Number(type))}
+                                    onChange={(e) => onFilterChange('types', Number(type), e.target.checked)}
+                                    className="h-4 w-4 rounded border border-input bg-background text-secondary appearance-none checked:bg-secondary checked:border-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                />
                                 <div dangerouslySetInnerHTML={{
                                     __html: createSvgContent(Number(type), 1, 0, 'shape')
                                 }} />
                                 <span>{dict.types[type].name}</span>
-                            </div>
+                            </label>
                         ))}
                     </div>
                 </div>
 
                 <div>
-                    <h4 className="font-medium mb-2">Status</h4>
+                    <h4 className="font-medium mb-2">{legendDict.statusTitle}</h4>
                     <div className="space-y-2">
                         {(Object.keys(dict.statuses) as Array<keyof typeof dict.statuses>).map((status) => (
-                            <div key={status} className="flex items-center gap-2">
+                            <label key={status} className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={filters.statuses.has(Number(status))}
+                                    onChange={(e) => onFilterChange('statuses', Number(status), e.target.checked)}
+                                    className="h-4 w-4 rounded border border-input bg-background text-secondary appearance-none checked:bg-secondary checked:border-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                />
                                 <div dangerouslySetInnerHTML={{
                                     __html: createSvgContent(1, 1, Number(status), 'color')
                                 }} />
                                 <span>{dict.statuses[status].name}</span>
-                            </div>
+                            </label>
                         ))}
                     </div>
                 </div>
+
                 <div>
-                    <h4 className="font-medium mb-2">Priorität</h4>
+                    <h4 className="font-medium mb-2">{legendDict.priorityTitle}</h4>
                     <div className="space-y-2">
                         {(Object.keys(dict.prios) as Array<keyof typeof dict.prios>).map((prio) => (
-                            <div key={prio} className="flex items-center gap-2">
-                                <div dangerouslySetInnerHTML={{
-                                    __html: createSvgContent(1, Number(prio), 0, 'size')
-                                }} />
+                            <label key={prio} className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={filters.prios.has(Number(prio))}
+                                    onChange={(e) => onFilterChange('prios', Number(prio), e.target.checked)}
+                                    className="h-4 w-4 rounded border border-input bg-background text-secondary appearance-none checked:bg-secondary checked:border-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                />
+                                <div
+                                    className="scale-90 -translate-y-1"
+                                    dangerouslySetInnerHTML={{
+                                        __html: createSvgContent(1, Number(prio), 0, 'size')
+                                    }} />
                                 <span>{dict.prios[prio].name}</span>
-                            </div>
+                            </label>
                         ))}
                     </div>
                 </div>

--- a/src/components/ReportOverview/Map/report-map.tsx
+++ b/src/components/ReportOverview/Map/report-map.tsx
@@ -78,7 +78,7 @@ export default function ReportMap({
 
     return (
         <div style={{ '--map-height': height } as React.CSSProperties}>
-            <div className="flex gap-4">
+            <div className="flex gap-4 relative z-0">
                 <div className="flex-1">
                     <MapWithNoSSR
                         reports={filteredReports}

--- a/src/components/ReportOverview/Map/report-map.tsx
+++ b/src/components/ReportOverview/Map/report-map.tsx
@@ -5,6 +5,7 @@ import 'leaflet/dist/leaflet.css';
 import type { Dictionary } from '@/dictionaries/dictionary';
 import { Skeleton } from "@/components/ui/skeleton";
 import Legend from './map-legend';
+import { useState, useMemo } from 'react';
 
 interface ReportMapProps {
     reports: {
@@ -39,7 +40,7 @@ const MapWithNoSSR = dynamic(
     {
         ssr: false,
         loading: () => (
-            <Skeleton className="w-full h-[600px] rounded-lg" />
+            <Skeleton className="w-full h-[620px] rounded-lg" />
         )
     }
 );
@@ -47,22 +48,50 @@ const MapWithNoSSR = dynamic(
 export default function ReportMap({
     reports,
     dictionary,
-    height = '400px',
+    height = '620px',
     worker = false,
 }: ReportMapProps) {
+    const [filters, setFilters] = useState({
+        types: new Set(Object.keys(dictionary.metadata.types).map(Number)),
+        statuses: new Set(Object.keys(dictionary.metadata.statuses).map(Number)),
+        prios: new Set(Object.keys(dictionary.metadata.prios).map(Number))
+    });
+
+    const handleFilterChange = (category: 'types' | 'statuses' | 'prios', id: number, checked: boolean) => {
+        setFilters(prev => ({
+            ...prev,
+            [category]: checked
+                ? new Set(prev[category]).add(id)
+                : new Set([...prev[category]].filter(x => x !== id))
+        }));
+    };
+
+    const filteredReports = useMemo(() => {
+        return reports.filter(report => {
+            const typeMatch = filters.types.has(report.typeId);
+            const prioMatch = filters.prios.has(report.prioId);
+            const statusMatch = report.protocols.length === 0 ||
+                filters.statuses.has(report.protocols[report.protocols.length - 1]?.statusId ?? 0);
+            return typeMatch && prioMatch && statusMatch;
+        });
+    }, [reports, filters]);
 
     return (
         <div style={{ '--map-height': height } as React.CSSProperties}>
             <div className="flex gap-4">
                 <div className="flex-1">
                     <MapWithNoSSR
-                        reports={reports}
+                        reports={filteredReports}
                         dictionary={dictionary}
                         worker={worker}
                     />
                 </div>
-                <div className="w-[200px]">
-                    <Legend dictionary={dictionary} />
+                <div className="w-[250px]">
+                    <Legend
+                        dictionary={dictionary}
+                        filters={filters}
+                        onFilterChange={handleFilterChange}
+                    />
                 </div>
             </div>
         </div>

--- a/src/dictionaries/de.json
+++ b/src/dictionaries/de.json
@@ -163,7 +163,10 @@
             "loading": "Wird geladen..."
         },
         "mapLegend": {
-            "title": "Legende"
+            "title": "Legende",
+            "typeTitle": "Typ",
+            "statusTitle": "Status",
+            "priorityTitle": "Priorität"
         },
         "reportTable": {
             "search": {
@@ -295,6 +298,10 @@
             "3": {
                 "name": "Abgeschlossen",
                 "description": "Meldung wurde bearbeitet"
+            },
+            "4": {
+                "name": "Abgelehnt",
+                "description": "Meldung wurde abgelehnt"
             }
         },
         "prios": {

--- a/src/dictionaries/dictionary.ts
+++ b/src/dictionaries/dictionary.ts
@@ -172,6 +172,9 @@ export interface Dictionary {
         },
         mapLegend: {
             title: string;
+            typeTitle: string;
+            statusTitle: string;
+            priorityTitle: string;
         },
         reportTable: {
             search: {
@@ -290,6 +293,7 @@ export interface Dictionary {
             "1": { name: string; description: string };
             "2": { name: string; description: string };
             "3": { name: string; description: string };
+            "4": { name: string; description: string };
         },
         prios: {
             "0": { name: string; description: string };

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -163,7 +163,10 @@
             "loading": "Loading..."
         },
         "mapLegend": {
-            "title": "Legend"
+            "title": "Legend",
+            "typeTitle": "Type",
+            "statusTitle": "Status",
+            "priorityTitle": "Priority"
         },
         "reportTable": {
             "search": {
@@ -295,6 +298,10 @@
             "3": {
                 "name": "Completed",
                 "description": "Report has been processed"
+            },
+            "4": {
+                "name": "Rejected",
+                "description": "Report has been rejected"
             }
         },
         "prios": {


### PR DESCRIPTION
This pull request adds filters to the map legend. The new filters allow users to easily toggle the visibility of different data layers on the map.

The key changes include:

- Implemented a new filters section in the map legend
- Added functionality to allow users to turn on/off different data layers
- Updated the UI to make the filters more intuitive and user-friendly

![CleanShot 2024-12-28 at 15 07 47](https://github.com/user-attachments/assets/edfb8b75-4ccd-441a-837c-86d8d86ae9c7)
![CleanShot 2024-12-28 at 15 08 14](https://github.com/user-attachments/assets/50565050-aa99-4c3f-aeec-49b42eca0d83)

