### PR TITLE
my-reports

### DIFF
--- a/src/server/db/schema/protocoll.ts
+++ b/src/server/db/schema/protocoll.ts
@@ -23,6 +23,7 @@ export const protocolls = createTable(
     (protocolls) => ({
         userIdIndex: index("userIdIndex").on(protocolls.userId),
         statusIdIndex: index("statusIdIndex").on(protocolls.statusId),
+        reportIdIndex: index("reportIdIndex").on(protocolls.reportId),
     })
 )
 


### PR DESCRIPTION
1. **Add index on reportId column in protocoll table**
   - This change adds an index on the `reportId` column in the `protocoll` table to optimize report fetching.

2. **Optimize report fetching and include associated data**
   - This feature optimizes the process of fetching reports and includes associated data.
   - It also ensures that users can only see their own reports, preventing them from accessing other users' reports.



## How it works
* First finds all protocols where:
  * The user is the current user
  * The protocol timestamp is the earliest one for that report
* Then gets all report details for these matches

## Real-world example
Bob is a Worker, Alice a User
* Alice creates Report A → She gets protocol "1"
* Bob creates Report B → He gets protocol "1"
* Bob comments on Report A → He gets protocol "2" with status 1 also
* **Result**: Alice sees Report A in her list, Bob sees Report B in his list and not A

## Why this matters
* Shows users the reports they initiated
* Helps track who was originally responsible for each report
* Protects user data